### PR TITLE
Rolling back version so it works again

### DIFF
--- a/KokoroTestApp.xcodeproj/project.pbxproj
+++ b/KokoroTestApp.xcodeproj/project.pbxproj
@@ -13,7 +13,24 @@
 		52FE05A32EAA8A200018FCF1 /* MLXUtilsLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 52FE05A22EAA8A200018FCF1 /* MLXUtilsLibrary */; };
 		52FE05CE2EAA938B0018FCF1 /* MisakiSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 52FE05CD2EAA938B0018FCF1 /* MisakiSwift */; };
 		52FE05F12EABBB5A0018FCF1 /* KokoroSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 52FE05F02EABBB5A0018FCF1 /* KokoroSwift */; };
+		AAAA00012EAA89F50018FCF1 /* KokoroSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 52FE059F2EAA89F50018FCF1 /* KokoroSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		AAAA00022EAA938B0018FCF1 /* MisakiSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 52FE05CD2EAA938B0018FCF1 /* MisakiSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AAAA00032EAA89F50018FCF1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				AAAA00012EAA89F50018FCF1 /* KokoroSwift in Embed Frameworks */,
+				AAAA00022EAA938B0018FCF1 /* MisakiSwift in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		5247E6922E8A5478003F2FA4 /* KokoroTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KokoroTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,6 +97,7 @@
 				5247E68E2E8A5478003F2FA4 /* Sources */,
 				5247E68F2E8A5478003F2FA4 /* Frameworks */,
 				5247E6902E8A5478003F2FA4 /* Resources */,
+				AAAA00032EAA89F50018FCF1 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -125,6 +143,8 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				52FE05EF2EABBB5A0018FCF1 /* XCRemoteSwiftPackageReference "kokoro-ios" */,
+				52FE05F12EABBB5B0018FCF2 /* XCRemoteSwiftPackageReference "mlx-swift" */,
+				52FE05F22EABBB5C0018FCF3 /* XCRemoteSwiftPackageReference "MisakiSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5247E6932E8A5478003F2FA4 /* Products */;
@@ -389,7 +409,23 @@
 			repositoryURL = "https://github.com/mlalma/kokoro-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.11;
+				version = 1.0.10;
+			};
+		};
+		52FE05F12EABBB5B0018FCF2 /* XCRemoteSwiftPackageReference "mlx-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift";
+			requirement = {
+				kind = exactVersion;
+				version = 0.29.1;
+			};
+		};
+		52FE05F22EABBB5C0018FCF3 /* XCRemoteSwiftPackageReference "MisakiSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mlalma/MisakiSwift";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/KokoroTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/KokoroTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlalma/kokoro-ios",
       "state" : {
-        "revision" : "4d6d1d8ff8cd012014180c9cd4cf0151e7682354",
-        "version" : "1.0.11"
+        "revision" : "9a1e2614e5898106d00eec7fd21ff2fc89d805a6",
+        "version" : "1.0.10"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mlalma/MisakiSwift",
       "state" : {
-        "revision" : "6835a1ce4a8854075c89f18ff75c74b13ef58e15",
-        "version" : "1.0.6"
+        "revision" : "bb5e3e3671ef550dc545a98f4a4c15f58ee649ec",
+        "version" : "1.0.5"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "f58bd2c2b3b84316da69182f436db4219aff30b9",
-        "version" : "0.30.2"
+        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
+        "version" : "0.29.1"
       }
     },
     {


### PR DESCRIPTION
Per what @iafan found in issue #7 (lightly edited for faster reading):

> I updated packages, which brought 
> - Kokoro from 1.0.10 to 1.0.11
> - mlx-swift from 0.29.1 to 0.30.2
> - MisakiSwift from 1.0.5 to 1.0.6 
> Now [...] I get just white noise-like sound (as if I'm just getting random data in the buffer, not audio). 
> Resetting dependencies to previous versions for these three packages solves the issue.

This rolls back the versions so the library works again. (Obviously better solution would be to make the new versions work, but that's not something I can help with.) 

This way others will still be able to use the library.

Also fixing a error that seems related, needing to change those libraries to Embed & Sign.